### PR TITLE
增加LeftMenu组件

### DIFF
--- a/src/components/LeftMenu/LeftMenu.css
+++ b/src/components/LeftMenu/LeftMenu.css
@@ -28,7 +28,6 @@ a {
   font-Family: PingFangSC-Medium;
   padding-top: 40px;
   font-size: 14px;
-  font-weight: bold;
 }
 .dark{
   box-shadow: 2px 0 7px 0 rgba(0,0,0,0.05);
@@ -38,7 +37,6 @@ a {
   font-Family: PingFangSC-Medium;
   padding-top: 40px;
   font-size: 14px;
-  font-weight: bold;
 }
 .menu_title{
   padding: 10px 20px;
@@ -46,7 +44,6 @@ a {
   opacity: 0.5;
   height: 40px;
   display: inline-block;
-  font-weight: bold;
 }
 .menu_list{
   position: relative;

--- a/src/components/LeftMenu/LeftMenu.css
+++ b/src/components/LeftMenu/LeftMenu.css
@@ -1,0 +1,94 @@
+#root{
+  height: 100%;
+  font-size: 14px;
+}
+
+i{
+  font-style: normal;
+}
+
+h3{
+  font-weight: normal;
+  font-size: 14px;
+}
+a {
+  text-decoration: none;
+}
+.dark a {
+  color: #fff;
+}
+.light a {
+  color: #555555;
+}
+.light{
+  box-shadow: 2px 0 4px 0 rgba(0,0,0,0.05);
+  height: calc(100% - 2px);
+  width: calc(100% - 4px);
+  box-sizing: border-box;
+  font-Family: PingFangSC-Medium;
+  padding-top: 40px;
+  font-size: 14px;
+  font-weight: bold;
+}
+.dark{
+  box-shadow: 2px 0 7px 0 rgba(0,0,0,0.05);
+  box-sizing: border-box;
+  height: calc(100% - 2px);
+  width: calc(100% - 2px);
+  font-Family: PingFangSC-Medium;
+  padding-top: 40px;
+  font-size: 14px;
+  font-weight: bold;
+}
+.menu_title{
+  padding: 10px 20px;
+  box-sizing: border-box;
+  opacity: 0.5;
+  height: 40px;
+  display: inline-block;
+  font-weight: bold;
+}
+.menu_list{
+  position: relative;
+  width: 100%;
+  height: 40px;
+  line-height: 39px;
+  opacity: 0.7;
+}
+.dark_active .menulist_name{
+  background-image: linear-gradient(to right, #4F95FB 0%, rgba(79,149,251,0.00) 100%);
+  opacity: 1;
+}
+.light_active div{
+  color: #0B95FE;
+}
+.light_active .menulist_name{
+  color: #0B95FE;
+}
+.menulist_name {
+  text-decoration: none;
+  box-sizing: border-box;
+  padding-left: 64px;
+  display: inline-block;
+  width: 100%;
+  line-height: 40px;
+  text-decoration: none;
+}
+.dark .menulist_name:hover{
+  background: rgba(79,149,251,.2);
+}
+.light .menulist_name:hover{
+  background: rgba(240,240,240,1);
+}
+.menulist_name:focus{
+  text-decoration: none;
+}
+.icon{
+  display: inline-block;
+  position: absolute;
+  left: 40px;
+  width: 20px;
+  height: 40px;
+  line-height: 40px;
+  font-size: 14px;
+}

--- a/src/components/LeftMenu/LeftMenu.js
+++ b/src/components/LeftMenu/LeftMenu.js
@@ -1,0 +1,42 @@
+//  @flow
+import React from 'react'
+import styles from './LeftMenu.css'
+
+const LeftMenu = (props: Object) => {
+  const lightThem = {
+    background: '#FAFAFA',
+    color: '#555555',
+  }
+  const darkThem = {
+    background: '#1E2A4D',
+    color: '#FFFFFF',
+  }
+  const them = props.them || 'light'
+  const raperStyle = them === 'light' ? lightThem : darkThem
+  return (
+    <div className={`${them}`} style={raperStyle}>
+      {props.children}
+    </div>
+  )
+}
+
+const SubMenu = (props: Object) => (
+  <div>
+    <div className={'menu_title'}>{props.name}</div>
+    {props.children}
+  </div>
+)
+
+const MenuItem = (props: Object) => {
+  return (
+    <div>
+      {props.icon}
+      <a href='javascript:void(0)'
+        className={'menulist_name'} >
+        {props.name}
+      </a>
+    </div>
+  )
+}
+
+export { SubMenu, MenuItem, LeftMenu }

--- a/src/components/LeftMenu/index.js
+++ b/src/components/LeftMenu/index.js
@@ -1,0 +1,3 @@
+import { SubMenu, MenuItem, LeftMenu } from './LeftMenu'
+
+export { SubMenu, MenuItem, LeftMenu }

--- a/src/components/LeftNav/LeftNav.js
+++ b/src/components/LeftNav/LeftNav.js
@@ -1,8 +1,7 @@
 import React from 'react'
-
 const lightThem = {
   background: '#FAFAFA',
-  color: '#555555',
+  color: '#555555'
 }
 const darkThem = {
   background: '#1E2A4D',
@@ -11,13 +10,13 @@ const darkThem = {
 const LeftNav = React.createClass({
   propTypes: {
     menu: React.PropTypes.array,
-    them: React.PropTypes.string,
+    them: React.PropTypes.string
   },
   getInitialState () {
     return {
       activeArr: [[true]],
       them: this.props.them,
-      menu: this.props.menu,
+      menu: this.props.menu
     }
   },
 
@@ -34,41 +33,44 @@ const LeftNav = React.createClass({
     return (
       <div className={`leftNav_wraper  ${them}`} style={raperStyle}>
         {
-          menu.map((item, index) => (
-            <ul key={item.name + index} >
+         menu.map((item, index) => (
+            item['subMenu']
+            ? <ul key={item.name + index} >
               <h3 className='menu_title' style={{ color: raperStyle.color }}>{item.name}</h3>
               {
-                item.children.map((menuList, menuListIndex) => {
-                  let classNames = `menu_list`
-                  if (activeArr[index]) {
-                    if (activeArr[index][menuListIndex]) {
-                      classNames = `menuList ${them}_active`
-                    }
-                  }
-                  return (
-                    <li
-                      className={classNames}
-                      key={menuList.name + menuListIndex}
-                      onClick={() => { this.handleActive(index, menuListIndex) }}
-                    >
-                      <div className='icon'>{menuList.icon}</div>
-                      <a href='javascript:void(0)'
-                        className='menulist_name' >
-                        {menuList.name}
-                      </a>
-                    </li>
-                  )
-                })
+               item.subMenu.map((menuList, menuListIndex) => {
+                 let classNames = `menu_list`
+                 if (activeArr[index]) {
+                   if (activeArr[index][menuListIndex]) {
+                     classNames = `menuList ${them}_active`
+                   }
+                 }
+                 return (
+                   <li
+                     className={classNames}
+                     key={menuList.name + menuListIndex}
+                     onClick={() => { this.handleActive(index, menuListIndex) }}
+                  >
+                     <div className={`icon ${menuList.icon}`} />
+                     <a href='javascript:void(0)'
+                       className='menulist_name' >
+                       {menuList.name}
+                     </a>
+                   </li>
+                 )
+               })
               }
             </ul>
+            : (
+              <ul key={item.name + index} >
+                <h3 className='menu_title' style={{ color: raperStyle.color }}>{item.name}</h3>
+              </ul>
+              )
           ))
         }
       </div>
     )
-  },
+  }
 })
 
 export default LeftNav
-
-LeftNav.defaultProps = {
-}

--- a/stories/LeftMenu.js
+++ b/stories/LeftMenu.js
@@ -1,0 +1,60 @@
+import { SubMenu, MenuItem, LeftMenu } from '../src/components/LeftMenu'
+import '../src/components/LeftMenu/LeftMenu.css'
+
+// demo:
+// const LeftMenus = (props) => {
+//   let { menu, them } = props
+//   them = them || 'light'
+//   return (
+//     <LeftMenu {...props} >
+//       {
+//         menu.map((item, index) => (
+//           item['subMenu']
+//           ? (
+//             <SubMenu name={item.name}>
+//               {
+//                 item.subMenu.map((subItem, subIndex) => (
+//                   <MenuItem
+//                     icon={(
+//                       <div
+//                         className={subItem['icon']}
+//                         style={{
+//                           position: 'absolute',
+//                           left: '40px',
+//                           width: '14px',
+//                           height: '40px',
+//                           lineHeight: '40px',
+//                           padding: '0',
+//                         }}
+//                       />
+//                     )}
+//                     name={subItem['name']}
+//                   />
+//                 ))
+//               }
+//             </SubMenu>
+//           )
+//           : (
+//             <MenuItem name={item.name}
+//               icon={(
+//                 <div
+//                   className={item['icon']}
+//                   style={{
+//                     position: 'absolute',
+//                     left: '40px',
+//                     width: '14px',
+//                     height: '40px',
+//                     lineHeight: '40px',
+//                     padding: '0',
+//                   }}
+//                 />
+//               )}
+//             />
+//           )
+//         ))
+//       }
+//     </LeftMenu>
+//   )
+// }
+
+export { SubMenu, MenuItem, LeftMenu }

--- a/stories/index.js
+++ b/stories/index.js
@@ -7,6 +7,7 @@ import Welcome from './Welcome'
 import Header from './Header'
 import Share from './Share'
 import LeftNav from './LeftNav'
+import { SubMenu, MenuItem, LeftMenu } from './LeftMenu'
 import { testValue1, testValue2 } from './headerConfig'
 import { menuList } from './leftNavConfig.js'
 let loading = false
@@ -17,6 +18,13 @@ function share (val) {
     loading = false
   }, 10000)
 }
+const LeftMenuDemo = (
+  <LeftMenu>
+    <SubMenu name='一级菜单'>
+      <MenuItem name='二级菜单' />
+    </SubMenu>
+  </LeftMenu>
+)
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />)
 
 storiesOf('Button', module)
@@ -29,6 +37,10 @@ storiesOf('Header', module)
 storiesOf('LeftNav', module)
 .add('light', () => <LeftNav {...menuList} them='light' />)
 .add('dark', () => <LeftNav {...menuList} them='dark' />)
+
+storiesOf('LeftMenu', module)
+.add('light', () => (<LeftMenu><SubMenu name='一级菜单'> <MenuItem name='二级菜单' /> </SubMenu> </LeftMenu>))
+.add('dark', () => (<LeftMenu them='dark'><SubMenu name='一级菜单'> <MenuItem name='二级菜单' /> </SubMenu> </LeftMenu>))
 
 storiesOf('Share', module)
   .add('default', () => <Share

--- a/stories/leftNavConfig.js
+++ b/stories/leftNavConfig.js
@@ -2,7 +2,7 @@ export const menuList = {
   menu: [
     {
       name: '',
-      children: [
+      subMenu: [
         {
           name: '概览',
           icon: '<',
@@ -11,7 +11,7 @@ export const menuList = {
     },
     {
       name: '时序数据',
-      children: [
+      subMenu: [
         {
           name: '同义字段',
           icon: '>',
@@ -24,7 +24,7 @@ export const menuList = {
     },
     {
       name: '关系数据',
-      children: [
+      subMenu: [
         {
           name: '同步任务',
           icon: '<',


### PR DESCRIPTION
使用方法: 
import { LeftMenu, MenuItem,  SubMenu } from 'k2-react-components/lib/Header/index.js'
组件说明:
LeftMenu: 最外层包裹组件,接收menu,them等参数
MenuItem: 一级菜单, 接收name参数
SubMenu: 二级菜单, 接收name,icon参数
参数说明:
menu: 所有子元素需要用到的数据,例:[
          {name: '用户管理', link: '/user', icon: 'fa fa-user-o'},
          {name: '时序数据', icon: 'fa fa-database', subMenu: [
            {name: `${fieldGroup}`, link: '/search/fieldGroup', icon: 'fa fa-th-large', similarStr: 'fieldGroup'}  
          ]}
        ]
them: 菜单主题,内设两款,默认为light,另一款为dark
icon: 实质为HTMLElement,需要用户自己写好样式传入,例:<MenuItem
                      icon={(
                        <div
                          className={subItem['icon']}
                          style={{
                            position: 'absolute',
                            left: '40px',
                            width: '14px',
                            height: '40px',
                            lineHeight: '40px',
                            padding: '0'
                          }}
                        />
                      )}
                      name={subItem['name']}
                    />
注: 鼠标点击后,MenuItem组件默认无样式变化,需要用Link包裹,并设置activeClassName为light_active或dark_active